### PR TITLE
feat: Notion API 래퍼 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,11 @@
   "dependencies": {
     "@gitbeaker/node": "~35.8.1",
     "@gitbeaker/requester-utils": "~43.3.0",
+    "@notionhq/client": "^4.0.1",
     "dotenv-flow": "^4.1.0",
     "ky": "^1.8.2",
     "ky-universal": "^0.12.0",
+    "p-queue": "^8.1.0",
     "zod": "^4.0.14"
   }
 }

--- a/src/lib/notion.test.ts
+++ b/src/lib/notion.test.ts
@@ -1,0 +1,403 @@
+import { jest } from '@jest/globals';
+import { Client } from '@notionhq/client';
+import { Logger, NotionApiWrapper, NotionConfig } from './notion';
+
+// Mock @notionhq/client
+jest.mock('@notionhq/client', () => ({
+  Client: jest.fn(),
+}));
+
+// Mock dotenv-flow
+jest.mock('dotenv-flow', () => ({
+  config: jest.fn(),
+}));
+
+// Mock p-queue
+jest.mock('p-queue', () => {
+  return jest.fn().mockImplementation(() => ({
+    add: jest.fn((fn: () => Promise<unknown>) => fn()),
+  }));
+});
+
+describe('NotionApiWrapper', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+  let mockLogger: jest.Mocked<Logger>;
+  let notionWrapper: NotionApiWrapper;
+
+  const mockConfig: NotionConfig = {
+    token: 'test-token',
+    databaseId: 'test-db-id',
+    uniqueKeyProperty: 'Unique Key',
+    timeout: 60000,
+    maxRetries: 3,
+    baseDelay: 100,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    NotionApiWrapper.resetForTests();
+
+    // Setup mock client
+    mockClient = {
+      pages: {
+        create: jest.fn(),
+        update: jest.fn(),
+        retrieve: jest.fn(),
+      },
+      databases: {
+        query: jest.fn(),
+        retrieve: jest.fn(),
+      },
+    };
+
+    (Client as unknown as jest.Mock).mockImplementation(() => mockClient);
+
+    // Setup mock logger
+    mockLogger = {
+      warn: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+
+    // Mock process.env
+    process.env.NOTION_TOKEN = 'test-token';
+    process.env.NOTION_DB_ID = 'test-db-id';
+  });
+
+  afterEach(() => {
+    delete process.env.NOTION_TOKEN;
+    delete process.env.NOTION_DB_ID;
+  });
+
+  describe('Singleton Pattern', () => {
+    it('should create only one instance', () => {
+      const instance1 = NotionApiWrapper.getInstance();
+      const instance2 = NotionApiWrapper.getInstance();
+
+      expect(instance1).toBe(instance2);
+    });
+
+    it('should reset instance for tests', () => {
+      const instance1 = NotionApiWrapper.getInstance();
+      NotionApiWrapper.resetForTests();
+      const instance2 = NotionApiWrapper.getInstance();
+
+      expect(instance1).not.toBe(instance2);
+    });
+  });
+
+  describe('Configuration', () => {
+    it('should parse environment variables correctly', () => {
+      notionWrapper = NotionApiWrapper.getInstance();
+      const config = notionWrapper.getConfig();
+
+      expect(config.token).toBe('test-token');
+      expect(config.databaseId).toBe('test-db-id');
+      expect(config.maxRetries).toBe(5); // default value
+      expect(config.baseDelay).toBe(1000); // default value
+    });
+
+    it('should use provided config when passed', () => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+      const config = notionWrapper.getConfig();
+
+      expect(config.token).toBe('test-token');
+      expect(config.databaseId).toBe('test-db-id');
+      expect(config.maxRetries).toBe(3);
+      expect(config.baseDelay).toBe(100);
+    });
+
+    it('should throw error when required env vars are missing', () => {
+      delete process.env.NOTION_TOKEN;
+      delete process.env.NOTION_DB_ID;
+
+      expect(() => {
+        NotionApiWrapper.getInstance();
+      }).toThrow('Invalid input: expected string, received undefined');
+    });
+  });
+
+  describe('createOrUpdatePage', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should create new page when page does not exist', async () => {
+      const mockPage = { id: 'new-page-id', properties: {} };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockSearchResults: any[] = [];
+
+      mockClient.databases.query.mockResolvedValue({
+        results: mockSearchResults,
+      });
+      mockClient.pages.create.mockResolvedValue(mockPage);
+
+      const result = await notionWrapper.createOrUpdatePage({
+        uniqueKey: 'test-key',
+        properties: {
+          Title: { title: [{ text: { content: 'Test Title' } }] },
+        },
+      });
+
+      expect(mockClient.databases.query).toHaveBeenCalledWith({
+        database_id: 'test-db-id',
+        filter: {
+          property: 'Unique Key',
+          title: { equals: 'test-key' },
+        },
+        page_size: 1,
+      });
+
+      expect(mockClient.pages.create).toHaveBeenCalledWith({
+        parent: { database_id: 'test-db-id' },
+        properties: {
+          Title: { title: [{ text: { content: 'Test Title' } }] },
+          'Unique Key': { title: [{ text: { content: 'test-key' } }] },
+        },
+      });
+
+      expect(result).toBe(mockPage);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Creating new page with unique key: test-key'
+      );
+    });
+
+    it('should update existing page when page exists', async () => {
+      const mockExistingPage = { id: 'existing-page-id', properties: {} };
+      const mockUpdatedPage = { id: 'existing-page-id', properties: {} };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockSearchResults: any[] = [mockExistingPage];
+
+      mockClient.databases.query.mockResolvedValue({
+        results: mockSearchResults,
+      });
+      mockClient.pages.update.mockResolvedValue(mockUpdatedPage);
+
+      const result = await notionWrapper.createOrUpdatePage({
+        uniqueKey: 'test-key',
+        properties: {
+          Title: { title: [{ text: { content: 'Updated Title' } }] },
+        },
+      });
+
+      expect(mockClient.pages.update).toHaveBeenCalledWith({
+        page_id: 'existing-page-id',
+        properties: {
+          Title: { title: [{ text: { content: 'Updated Title' } }] },
+        },
+      });
+
+      expect(result).toBe(mockUpdatedPage);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Updating existing page with unique key: test-key'
+      );
+    });
+  });
+
+  describe('queryDatabase', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should query database with filter', async () => {
+      const mockResults = [{ id: 'page-1' }, { id: 'page-2' }];
+      mockClient.databases.query.mockResolvedValue({ results: mockResults });
+
+      const result = await notionWrapper.queryDatabase({
+        filter: {
+          property: 'Status',
+          title: { equals: 'Active' },
+        },
+        page_size: 50,
+      });
+
+      expect(mockClient.databases.query).toHaveBeenCalledWith({
+        database_id: 'test-db-id',
+        filter: {
+          property: 'Status',
+          title: { equals: 'Active' },
+        },
+        page_size: 50,
+      });
+
+      expect(result).toBe(mockResults);
+    });
+
+    it('should query database without filter', async () => {
+      const mockResults = [{ id: 'page-1' }];
+      mockClient.databases.query.mockResolvedValue({ results: mockResults });
+
+      const result = await notionWrapper.queryDatabase({});
+
+      expect(mockClient.databases.query).toHaveBeenCalledWith({
+        database_id: 'test-db-id',
+      });
+
+      expect(result).toBe(mockResults);
+    });
+  });
+
+  describe('getPage', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should retrieve page by ID', async () => {
+      const mockPage = { id: 'page-id', properties: {} };
+      mockClient.pages.retrieve.mockResolvedValue(mockPage);
+
+      const result = await notionWrapper.getPage('page-id');
+
+      expect(mockClient.pages.retrieve).toHaveBeenCalledWith({
+        page_id: 'page-id',
+      });
+
+      expect(result).toBe(mockPage);
+    });
+  });
+
+  describe('updatePage', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should update page properties', async () => {
+      const mockUpdatedPage = { id: 'page-id', properties: {} };
+      mockClient.pages.update.mockResolvedValue(mockUpdatedPage);
+
+      const properties = {
+        Title: { title: [{ text: { content: 'Updated Title' } }] },
+      };
+
+      const result = await notionWrapper.updatePage('page-id', properties);
+
+      expect(mockClient.pages.update).toHaveBeenCalledWith({
+        page_id: 'page-id',
+        properties,
+      });
+
+      expect(result).toBe(mockUpdatedPage);
+    });
+  });
+
+  describe('archivePage', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should archive page', async () => {
+      const mockArchivedPage = { id: 'page-id', archived: true };
+      mockClient.pages.update.mockResolvedValue(mockArchivedPage);
+
+      const result = await notionWrapper.archivePage('page-id');
+
+      expect(mockClient.pages.update).toHaveBeenCalledWith({
+        page_id: 'page-id',
+        archived: true,
+      });
+
+      expect(result).toBe(mockArchivedPage);
+    });
+  });
+
+  describe('getDatabase', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should retrieve database information', async () => {
+      const mockDatabase = { id: 'db-id', title: 'Test Database' };
+      mockClient.databases.retrieve.mockResolvedValue(mockDatabase);
+
+      const result = await notionWrapper.getDatabase();
+
+      expect(mockClient.databases.retrieve).toHaveBeenCalledWith({
+        database_id: 'test-db-id',
+      });
+
+      expect(result).toBe(mockDatabase);
+    });
+  });
+
+  describe('Rate Limiting and Retry', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should retry on rate limit error and eventually succeed', async () => {
+      const mockPage = { id: 'page-id', properties: {} };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rateLimitError = new Error('Rate limited') as any;
+      rateLimitError.status = 429;
+
+      // Mock to fail twice with rate limit, then succeed
+      mockClient.pages.retrieve
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce(mockPage);
+
+      const result = await notionWrapper.getPage('page-id');
+
+      expect(mockClient.pages.retrieve).toHaveBeenCalledTimes(3);
+      expect(mockLogger.warn).toHaveBeenCalledTimes(2);
+      expect(result).toBe(mockPage);
+    });
+
+    it('should throw error after max retries', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rateLimitError = new Error('Rate limited') as any;
+      rateLimitError.status = 429;
+
+      // Mock to always fail with rate limit
+      mockClient.pages.retrieve.mockRejectedValue(rateLimitError);
+
+      await expect(notionWrapper.getPage('page-id')).rejects.toThrow(
+        'Rate limited'
+      );
+      expect(mockClient.pages.retrieve).toHaveBeenCalledTimes(4); // 1 initial + 3 retries
+      expect(mockLogger.warn).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry on non-rate-limit errors', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const otherError = new Error('Other error') as any;
+      otherError.status = 500;
+
+      mockClient.pages.retrieve.mockRejectedValue(otherError);
+
+      await expect(notionWrapper.getPage('page-id')).rejects.toThrow(
+        'Other error'
+      );
+      expect(mockClient.pages.retrieve).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error Handling', () => {
+    beforeEach(() => {
+      notionWrapper = NotionApiWrapper.getInstance(mockConfig, mockLogger);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const apiError = new Error('API Error') as any;
+      apiError.status = 400;
+      mockClient.pages.retrieve.mockRejectedValue(apiError);
+
+      await expect(notionWrapper.getPage('page-id')).rejects.toThrow(
+        'API Error'
+      );
+    });
+
+    it('should handle network errors', async () => {
+      const networkError = new Error('Network Error');
+      mockClient.pages.retrieve.mockRejectedValue(networkError);
+
+      await expect(notionWrapper.getPage('page-id')).rejects.toThrow(
+        'Network Error'
+      );
+    });
+  });
+});

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,0 +1,327 @@
+import { Client } from '@notionhq/client';
+import type {
+  QueryDatabaseParameters,
+  CreatePageParameters,
+  SearchParameters,
+  PageObjectResponse,
+  DatabaseObjectResponse,
+} from '@notionhq/client/build/src/api-endpoints';
+import { z } from 'zod';
+import dotenvFlow from 'dotenv-flow';
+import PQueue from 'p-queue';
+
+// Load environment variables
+dotenvFlow.config();
+
+// Environment variable schema
+const envSchema = z.object({
+  NOTION_TOKEN: z.string().min(1, 'NOTION_TOKEN is required'),
+  NOTION_DB_ID: z.string().min(1, 'NOTION_DB_ID is required'),
+  NOTION_UNIQUE_KEY_PROP: z.string().optional(),
+});
+
+// 공식 Notion 속성 타입
+export type PropertiesMap = CreatePageParameters['properties'];
+export type SearchResult = PageObjectResponse | DatabaseObjectResponse;
+
+// Create or update page parameters
+export interface CreateOrUpdatePageParams {
+  uniqueKey: string;
+  properties: PropertiesMap;
+  parent?: { database_id: string };
+}
+
+// Query database parameters (Notion 공식 타입 활용)
+export type QueryDatabaseParams = Omit<
+  QueryDatabaseParameters,
+  'database_id'
+> & {
+  database_id?: string;
+};
+
+// Logger interface for dependency injection
+export interface Logger {
+  warn(message: string, meta?: unknown): void;
+  error(message: string, meta?: unknown): void;
+  info(message: string, meta?: unknown): void;
+  debug(message: string, meta?: unknown): void;
+}
+
+// Default console logger
+const defaultLogger: Logger = {
+  warn: (message, meta) => console.warn(message, meta),
+  error: (message, meta) => console.error(message, meta),
+  info: (message, meta) => console.info(message, meta),
+  debug: (message, meta) => console.debug(message, meta),
+};
+
+// Configuration interface
+export interface NotionConfig {
+  token: string;
+  databaseId: string;
+  uniqueKeyProperty: string;
+  timeout?: number;
+  maxRetries?: number;
+  baseDelay?: number;
+}
+
+const DEFAULT_UNIQUE_KEY_PROP = 'Unique Key';
+const DEFAULT_MAX_RETRIES = 5;
+const DEFAULT_BASE_DELAY = 1000; // 1 second
+const RATE_LIMIT_STATUS = 429;
+
+export class NotionApiWrapper {
+  private static instance: NotionApiWrapper;
+  private readonly client: Client;
+  private readonly logger: Logger;
+  private readonly config: NotionConfig;
+  private readonly queue: PQueue;
+
+  private constructor(config?: Partial<NotionConfig>, logger?: Logger) {
+    this.logger = logger || defaultLogger;
+    this.config = this.parseEnvConfig(config);
+    this.client = new Client({
+      auth: this.config.token,
+      timeoutMs: this.config.timeout || 60000,
+    });
+    this.queue = new PQueue({ concurrency: 3 });
+  }
+
+  private parseEnvConfig(override?: Partial<NotionConfig>): NotionConfig {
+    const env = envSchema.parse(process.env);
+    return {
+      token: override?.token || env.NOTION_TOKEN,
+      databaseId: override?.databaseId || env.NOTION_DB_ID,
+      uniqueKeyProperty:
+        override?.uniqueKeyProperty ||
+        env.NOTION_UNIQUE_KEY_PROP ||
+        DEFAULT_UNIQUE_KEY_PROP,
+      timeout: override?.timeout || 60000,
+      maxRetries: override?.maxRetries || DEFAULT_MAX_RETRIES,
+      baseDelay: override?.baseDelay || DEFAULT_BASE_DELAY,
+    };
+  }
+
+  public static getInstance(
+    config?: Partial<NotionConfig>,
+    logger?: Logger
+  ): NotionApiWrapper {
+    if (!NotionApiWrapper.instance) {
+      NotionApiWrapper.instance = new NotionApiWrapper(config, logger);
+    }
+    return NotionApiWrapper.instance;
+  }
+
+  public static resetForTests(): void {
+    NotionApiWrapper.instance = undefined as unknown as NotionApiWrapper;
+  }
+
+  public getClient(): Client {
+    return this.client;
+  }
+
+  public getConfig(): NotionConfig {
+    return this.config;
+  }
+
+  /**
+   * Exponential backoff retry function
+   */
+  private async withRetry<T>(
+    operation: () => Promise<T>,
+    maxRetries: number = this.config.maxRetries || DEFAULT_MAX_RETRIES
+  ): Promise<T> {
+    let lastError: Error;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await operation();
+      } catch (error: unknown) {
+        const err = error as Error & { status?: number; code?: string };
+        lastError = err;
+        // Notion SDK: error.status === 429 or error.code === APIErrorCode.RateLimited
+        if (
+          (err.status === RATE_LIMIT_STATUS || err.code === 'rate_limited') &&
+          attempt < maxRetries
+        ) {
+          const delay =
+            (this.config.baseDelay || DEFAULT_BASE_DELAY) *
+            Math.pow(2, attempt);
+          this.logger.warn(
+            `Rate limit hit, retrying in ${delay}ms (attempt ${attempt + 1}/$${
+              maxRetries + 1
+            })`
+          );
+          await new Promise(resolve => globalThis.setTimeout(resolve, delay));
+          continue;
+        }
+        break;
+      }
+    }
+    throw lastError!;
+  }
+
+  /**
+   * Create or update a page in Notion database (Upsert)
+   */
+  public async createOrUpdatePage(
+    params: CreateOrUpdatePageParams
+  ): Promise<PageObjectResponse> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const { uniqueKey, properties, parent } = params;
+        const uniqueKeyProp = this.config.uniqueKeyProperty;
+        const existingPage = await this.findPageByUniqueKey(uniqueKey);
+        let result: unknown;
+        if (existingPage) {
+          this.logger.info(
+            `Updating existing page with unique key: ${uniqueKey}`
+          );
+          result = await this.client.pages.update({
+            page_id: existingPage.id,
+            properties,
+          });
+        } else {
+          this.logger.info(`Creating new page with unique key: ${uniqueKey}`);
+          result = await this.client.pages.create({
+            parent: parent || { database_id: this.config.databaseId },
+            properties: {
+              ...properties,
+              [uniqueKeyProp]: {
+                title: [{ text: { content: uniqueKey } }],
+              },
+            },
+          });
+        }
+        return result as PageObjectResponse;
+      })
+    ) as Promise<PageObjectResponse>;
+  }
+
+  /**
+   * Query Notion database (databases.query)
+   */
+  public async queryDatabase(
+    params: QueryDatabaseParams = {}
+  ): Promise<PageObjectResponse[]> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const response: unknown = await this.client.databases.query({
+          database_id: params.database_id || this.config.databaseId,
+          ...params,
+        });
+        return (response as { results: unknown[] })
+          .results as PageObjectResponse[];
+      })
+    ) as Promise<PageObjectResponse[]>;
+  }
+
+  /**
+   * Find a page by unique key property
+   */
+  private async findPageByUniqueKey(
+    uniqueKey: string
+  ): Promise<PageObjectResponse | null> {
+    const uniqueKeyProp = this.config.uniqueKeyProperty;
+    const results = await this.queryDatabase({
+      filter: {
+        property: uniqueKeyProp,
+        title: {
+          equals: uniqueKey,
+        },
+      },
+      page_size: 1,
+    });
+    return results.length > 0 ? results[0] : null;
+  }
+
+  /**
+   * Retrieve a page by ID
+   */
+  public async getPage(pageId: string): Promise<PageObjectResponse> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const result: unknown = await this.client.pages.retrieve({
+          page_id: pageId,
+        });
+        return result as PageObjectResponse;
+      })
+    ) as Promise<PageObjectResponse>;
+  }
+
+  /**
+   * Update a page by ID
+   */
+  public async updatePage(
+    pageId: string,
+    properties: PropertiesMap
+  ): Promise<PageObjectResponse> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const result: unknown = await this.client.pages.update({
+          page_id: pageId,
+          properties,
+        });
+        return result as PageObjectResponse;
+      })
+    ) as Promise<PageObjectResponse>;
+  }
+
+  /**
+   * Archive (delete) a page by ID
+   */
+  public async archivePage(pageId: string): Promise<PageObjectResponse> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const result: unknown = await this.client.pages.update({
+          page_id: pageId,
+          archived: true,
+        });
+        return result as PageObjectResponse;
+      })
+    ) as Promise<PageObjectResponse>;
+  }
+
+  /**
+   * Get database information
+   */
+  public async getDatabase(): Promise<unknown> {
+    return this.queue.add(async () =>
+      this.withRetry(
+        async () =>
+          await this.client.databases.retrieve({
+            database_id: this.config.databaseId,
+          })
+      )
+    );
+  }
+
+  /**
+   * Global search (client.search)
+   */
+  public async globalSearch(
+    params: Omit<SearchParameters, 'auth'>
+  ): Promise<SearchResult[]> {
+    return this.queue.add(async () =>
+      this.withRetry(async () => {
+        const response: unknown = await this.client.search(params);
+        return (response as { results: SearchResult[] }).results;
+      })
+    ) as Promise<SearchResult[]>;
+  }
+}
+
+// Export convenience functions
+export const getClient = () => NotionApiWrapper.getInstance().getClient();
+export const createOrUpdatePage = (params: CreateOrUpdatePageParams) =>
+  NotionApiWrapper.getInstance().createOrUpdatePage(params);
+export const queryDatabase = (params: QueryDatabaseParams) =>
+  NotionApiWrapper.getInstance().queryDatabase(params);
+export const getPage = (pageId: string) =>
+  NotionApiWrapper.getInstance().getPage(pageId);
+export const updatePage = (pageId: string, properties: PropertiesMap) =>
+  NotionApiWrapper.getInstance().updatePage(pageId, properties);
+export const archivePage = (pageId: string) =>
+  NotionApiWrapper.getInstance().archivePage(pageId);
+export const getDatabase = () => NotionApiWrapper.getInstance().getDatabase();
+export const globalSearch = (params: Omit<SearchParameters, 'auth'>) =>
+  NotionApiWrapper.getInstance().globalSearch(params);

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,6 +993,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@notionhq/client@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@notionhq/client@npm:4.0.1"
+  checksum: 10c0/bb635dc273ae9fa63909e2df805939ebd4947bf8f59dc9abeae1c6dfcc246927838060b7b226071cdd77908dfd79db2c68e997a5dd579f39849bb1ee2d7bc989
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^3.0.0":
   version: 3.0.0
   resolution: "@npmcli/agent@npm:3.0.0"
@@ -2206,6 +2213,7 @@ __metadata:
   dependencies:
     "@gitbeaker/node": "npm:~35.8.1"
     "@gitbeaker/requester-utils": "npm:~43.3.0"
+    "@notionhq/client": "npm:^4.0.1"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.1.0"
     "@typescript-eslint/eslint-plugin": "npm:^8.38.0"
@@ -2219,6 +2227,7 @@ __metadata:
     ky: "npm:^1.8.2"
     ky-universal: "npm:^0.12.0"
     lint-staged: "npm:^16.1.2"
+    p-queue: "npm:^8.1.0"
     prettier: "npm:^3.6.2"
     ts-jest: "npm:^29.4.0"
     ts-node: "npm:^10.9.2"
@@ -4502,6 +4511,23 @@ __metadata:
   version: 7.0.3
   resolution: "p-map@npm:7.0.3"
   checksum: 10c0/46091610da2b38ce47bcd1d8b4835a6fa4e832848a6682cf1652bc93915770f4617afc844c10a77d1b3e56d2472bb2d5622353fa3ead01a7f42b04fc8e744a5c
+  languageName: node
+  linkType: hard
+
+"p-queue@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "p-queue@npm:8.1.0"
+  dependencies:
+    eventemitter3: "npm:^5.0.1"
+    p-timeout: "npm:^6.1.2"
+  checksum: 10c0/6bdea170840546769c29682fed212745c951933476761ed3a981967fab624c7c0120dff79bd99a1ac8b650b420719a245813e944af4b8ee77d4dd78adbf5fe75
+  languageName: node
+  linkType: hard
+
+"p-timeout@npm:^6.1.2":
+  version: 6.1.4
+  resolution: "p-timeout@npm:6.1.4"
+  checksum: 10c0/019edad1c649ab07552aa456e40ce7575c4b8ae863191477f02ac8d283ac8c66cedef0ca93422735130477a051dfe952ba717641673fd3599befdd13f63bcc33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 Summary

Notion API 래퍼를 구현하여 데이터베이스 CRUD 작업을 중앙화하고 레이트 리밋을 관리하는 기능을 추가했습니다.

## 🔖 Type of change

- [x] ✨ **Feature** (새 Job·기능)
- [ ] �� **Bug fix** (문제 해결)
- [ ] ♻️ **Refactor** (동작 동일, 구조 개선)
- [ ] 📝 **Docs** (문서·주석·README)
- [ ] �� **CI/CD** (워크플로·빌드·릴리스)
- [ ] 🧹 **Chore** (의존성 업데이트 등)

## 🔗 Related Issue / Discussion

<!-- e.g. Closes #123, Relates to #45 -->

## �� What was done

- `src/lib/notion.ts`에 Singleton 패턴의 `NotionApiWrapper` 클래스 구현
- `createOrUpdatePage()` 메서드로 Upsert 기능 구현 (중복 방지)
- `withRetry()` 함수로 레이트 리밋(429) 시 지수 백오프 재시도 로직 추가
- `p-queue`를 활용한 동시성 제어 (3 req/sec)
- 공식 Notion SDK 타입(`CreatePageParameters`, `PageObjectResponse` 등) 활용으로 타입 안전성 확보
- `src/lib/notion.test.ts`에 18개 테스트 케이스 작성 (성공/실패/재시도 시나리오)
- `@notionhq/client` 및 `p-queue` 의존성 추가

## ✅ Checklist

- [x] 코드가 **lint / test / build** 모두 통과
- [x] 필요한 **단위·통합 테스트**를 작성/수정
- [ ] **CHANGELOG.md** 업데이트 (해당 시)
- [ ] 새/변경 **환경변수**를 README에 명시
- [ ] 리뷰어가 이해할 수 있도록 **스크린샷·로그** 첨부 (UI/로그 변경 시)

## 🧪 How to test

```bash
# 단위 테스트 실행
yarn test src/lib/notion.test.ts

# 린트 검사
yarn lint src/lib/notion.ts src/lib/notion.test.ts

# 전체 테스트 스위트 실행
yarn test
```

**테스트 결과:**
```
Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        2.167 s
```

**주요 테스트 시나리오:**
- Singleton 패턴 검증
- 환경변수 파싱 및 설정
- Upsert 기능 (생성/업데이트)
- 레이트 리밋 재시도 로직
- 에러 핸들링 (API/네트워크 에러)