### PR TITLE
feat: MR 동기화를 작성자 기준으로 마이그레이션

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,20 @@ Automatically syncs GitLab merge requests to Notion database on a weekly basis.
 
 **Features**:
 
-- Syncs merged MRs from the last 7 days
+- Syncs merged MRs from the last 7 days by author across all projects or specific project
 - Uses MR IID as unique key for upsert operations
 - Maps MR properties to Notion database fields
 - Handles errors gracefully with retry logic
 - Provides detailed logging and metrics
+- Supports both author-based filtering (all projects) and project-specific filtering
 
 **Environment Variables Required**:
 
 ```env
 GITLAB_HOST=https://gitlab.example.com
 GITLAB_TOKEN=your-gitlab-token
-GITLAB_PROJECT_ID=your-project-id
+GITLAB_AUTHOR_USERNAME=your-gitlab-username
+GITLAB_PROJECT_ID=your-project-id  # Optional: if not provided, searches all projects
 NOTION_TOKEN=your-notion-token
 NOTION_DB_ID=your-database-id
 NOTION_UNIQUE_KEY_PROP=MR IID  # Optional, defaults to "MR IID"


### PR DESCRIPTION
PR 템플릿을 참고하여 디스크립션을 작성해드리겠습니다.

## �� Summary

GitLab MR 동기화 Job을 프로젝트 ID 기준에서 **작성자(author) 기준**으로 마이그레이션하여 여러 프로젝트에 걸친 활동을 한 번에 기록할 수 있도록 개선했습니다.

## 🔖 Type of change

- [x] ✨ **Feature** (새 Job·기능)
- [ ] �� **Bug fix** (문제 해결)
- [ ] ♻️ **Refactor** (동작 동일, 구조 개선)
- [ ] 📝 **Docs** (문서·주석·README)
- [ ] �� **CI/CD** (워크플로·빌드·릴리스)
- [ ] 🧹 **Chore** (의존성 업데이트 등)

## 🔗 Related Issue / Discussion

Closes #4 Sync GitLab MRs to Notion (Upsert)
Relates to #2 Implement GitLab API wrapper

## �� What was done

- `src/lib/gitlab.ts`에 `listMergedMRsByAuthor()` 함수 추가
- `src/jobs/syncMrNotion.ts`를 author 기반 MR 조회로 변경
- `GITLAB_AUTHOR_USERNAME` 환경변수 추가 및 스키마 업데이트
- 프로젝트 ID 선택적 지정 지원 (미지정 시 모든 프로젝트 대상)
- `src/lib/gitlab.test.ts`에 author 필터 테스트 시나리오 추가
- `src/jobs/syncMrNotion.test.ts`를 새로운 함수 사용으로 업데이트
- `README.md` 환경변수 및 기능 설명 업데이트

## ✅ Checklist

- [x] 코드가 **lint / test / build** 모두 통과
- [x] 필요한 **단위·통합 테스트**를 작성/수정
- [ ] **CHANGELOG.md** 업데이트 (해당 시)
- [x] 새/변경 **환경변수**를 README에 명시
- [ ] 리뷰어가 이해할 수 있도록 **스크린샷·로그** 첨부 (UI/로그 변경 시)

## 🧪 How to test

```bash
# 테스트 실행
yarn test

# 수동 실행 (환경변수 설정 후)
yarn build
JOB=syncMr node dist/jobs/index.js
```

**환경변수 설정:**
```env
GITLAB_AUTHOR_USERNAME=your-gitlab-username
GITLAB_PROJECT_ID=your-project-id  # Optional: 미지정 시 모든 프로젝트 대상
```

**테스트 결과:** 57개 테스트 모두 통과 ✅